### PR TITLE
Add custom_sale_price_control: torna campos fiscal_price e price_unit…

### DIFF
--- a/custom_sale_price_control/__init__.py
+++ b/custom_sale_price_control/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/custom_sale_price_control/__manifest__.py
+++ b/custom_sale_price_control/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    'name': 'Sale Price Control',
+    'version': '14.0.1.0.0',
+    'summary': 'Bloqueia edição manual dos campos price_unit e fiscal_price em linhas de venda',
+    'author': 'Falker, Édison',
+    'depends': ['sale', 'l10n_br_sale'],
+    'data': [
+        'views/sale_order_line_view.xml',
+    ],
+    'installable': True,
+    'application': False,
+}

--- a/custom_sale_price_control/models/__init__.py
+++ b/custom_sale_price_control/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order_line

--- a/custom_sale_price_control/models/sale_order_line.py
+++ b/custom_sale_price_control/models/sale_order_line.py
@@ -1,0 +1,21 @@
+from odoo import models, fields, api
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    fiscal_price = fields.Float(
+        string="Preço Fiscal",
+        compute="_compute_fiscal_price",
+        store=True,
+        readonly=True,
+        help="Preço fiscal calculado automaticamente (inclui impostos brasileiros)."
+    )
+
+    @api.depends('price_unit', 'fiscal_tax_ids', 'product_id')
+    def _compute_fiscal_price(self):
+        for line in self:
+            if hasattr(super(), '_compute_fiscal_price'):
+                super(SaleOrderLine, line)._compute_fiscal_price()
+            else:
+                line.fiscal_price = line.price_unit
+

--- a/custom_sale_price_control/views/sale_order_line_view.xml
+++ b/custom_sale_price_control/views/sale_order_line_view.xml
@@ -1,0 +1,25 @@
+<odoo>
+  <data>
+
+    <!-- Herda a view de formulário da linha de pedido de venda -->
+    <record id="view_order_form_sale_lock_price" model="ir.ui.view">
+      <field name="name">sale.order.line.lock.price</field>
+      <field name="model">sale.order</field>
+      <field name="inherit_id" ref="sale.view_order_form"/>
+      <field name="arch" type="xml">
+
+        <!-- Torna price_unit somente leitura -->
+        <xpath expr="//field[@name='order_line']/form//field[@name='price_unit']" position="attributes">
+          <attribute name="readonly">1</attribute>
+        </xpath>
+
+        <!-- Torna o valor fiscal (price_tax) somente leitura -->
+        <xpath expr="//field[@name='order_line']/form//field[@name='price_tax']" position="attributes">
+          <attribute name="readonly">1</attribute>
+        </xpath>
+
+      </field>
+    </record>
+
+  </data>
+</odoo>


### PR DESCRIPTION
### Novo Módulo: custom_sale_price_control
- Torna campos fiscal_price e price_unit como readonly
- Compatível com Odoo 14.
- Dependências: "sale", "l10n_br_sale"
- Instruções de teste: Percorrer o fluxo de vendas, gerando PVs e com diferentes produtos que constam nas listas de preço, seguindo o fluxo até gerar NFs, comparar valores de impostos utilizando a base prod erp.falker.com.br