### PR TITLE
[ADD] falker_sale_price_control: make fiscal_price and price_unit readonly

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.28
+_commit: v1.32
 _src_path: gh:oca/oca-addons-repo-template
 ci: GitHub
 convert_readme_fragments_to_markdown: false

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: "3.11"
       - name: Get python version
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,6 +104,7 @@ repos:
         additional_dependencies:
           - "eslint@7.8.1"
           - "eslint-plugin-jsdoc@"
+          - "globals@"
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:

--- a/falker_sale_price_control/__init__.py
+++ b/falker_sale_price_control/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/falker_sale_price_control/__manifest__.py
+++ b/falker_sale_price_control/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    "name": "Sale Price Control",
+    "version": "14.0.1.0.0",
+    "summary": "Control for sale order line prices",
+    "author": "Escodoo",
+    "license": "AGPL-3",
+    "website": "https://github.com/Escodoo/falker-addons",
+    "depends": ["l10n_br_sale"],
+    "data": ["views/sale_order_line_view.xml"],
+    "demo": [],
+    "test": ["tests/test_sale_order_line.py"],
+    "installable": True,
+    "application": False,
+    "auto_install": False,
+}

--- a/falker_sale_price_control/models/__init__.py
+++ b/falker_sale_price_control/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order_line

--- a/falker_sale_price_control/models/sale_order_line.py
+++ b/falker_sale_price_control/models/sale_order_line.py
@@ -1,0 +1,71 @@
+from odoo import api, fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    fiscal_price = fields.Float(
+        string="Preço Fiscal",
+        compute="_compute_fiscal_price",
+        store=True,
+    )
+
+    @api.depends("price_unit", "fiscal_tax_ids", "product_id", "order_id.pricelist_id")
+    def _compute_fiscal_price(self):
+        for line in self:
+            if hasattr(super(), "_compute_fiscal_price"):
+                super(SaleOrderLine, line)._compute_fiscal_price()
+            else:
+                line.fiscal_price = line.price_unit
+
+    @api.model
+    def create(self, values):
+        return super().create(values)
+
+    def write(self, vals):
+        # Checks if the order has a different pricelist from the one in the context
+        if "pricelist_id" not in vals and any(
+            line.order_id.pricelist_id.id
+            != self.env.context.get("default_pricelist_id")
+            for line in self
+            if line.order_id
+        ):
+            vals["price_unit"] = self._get_price_from_pricelist()
+
+        # Att when change the product
+        if "product_id" in vals:
+            for line in self:
+                order = line.order_id
+                product = self.env["product.product"].browse(vals["product_id"])
+                quantity = vals.get("product_uom_qty", line.product_uom_qty)
+
+                if order.pricelist_id:
+                    price = order.pricelist_id.with_context(
+                        uom=product.uom_id.id, date=order.date_order
+                    ).get_product_price(product, quantity, order.partner_id)
+
+                    vals["price_unit"] = price
+                    vals["fiscal_price"] = price
+
+        return super().write(vals)
+
+    def _get_price_from_pricelist(self):
+        """Obtém o preço atualizado da lista de preços com tratamento para linhas vazias"""
+        self.ensure_one()
+
+        # If it's a line without product, return 0
+        if not self.product_id or self.display_type == "line_note":
+            return 0.0
+
+        return self.order_id.pricelist_id.with_context(
+            uom=self.product_uom.id, date=self.order_id.date_order
+        ).get_product_price(
+            self.product_id, self.product_uom_qty, self.order_id.partner_id
+        )
+
+    @api.onchange("product_id")
+    def _onchange_product_id_custom_price(self):
+        if not self.product_id:
+            return
+        self.product_id_change()
+        self._compute_tax_id()

--- a/falker_sale_price_control/tests/__init__.py
+++ b/falker_sale_price_control/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_order_line

--- a/falker_sale_price_control/tests/test_sale_order_line.py
+++ b/falker_sale_price_control/tests/test_sale_order_line.py
@@ -1,0 +1,157 @@
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestSaleOrderLinePriceControl(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.tax_icms = self.env["account.tax"].create(
+            {
+                "name": "ICMS Test",
+                "type_tax_use": "sale",
+                "amount_type": "percent",
+                "amount": 17.0,
+            }
+        )
+
+        self.product = self.env["product.product"].create(
+            {
+                "name": "Test Product",
+                "list_price": 100.0,
+                "taxes_id": [(6, 0, [self.tax_icms.id])],
+            }
+        )
+
+        self.new_product = self.env["product.product"].create(
+            {
+                "name": "New Test Product",
+                "list_price": 200.0,
+                "taxes_id": [(6, 0, [self.tax_icms.id])],
+            }
+        )
+
+        self.pricelist = self.env["product.pricelist"].create(
+            {
+                "name": "Test Pricelist",
+                "currency_id": self.env.company.currency_id.id,
+            }
+        )
+
+        self.pricelist_item = self.env["product.pricelist.item"].create(
+            {
+                "pricelist_id": self.pricelist.id,
+                "applied_on": "0_product_variant",
+                "product_id": self.new_product.id,
+                "fixed_price": 150.0,
+            }
+        )
+
+        self.order = self.env["sale.order"].create(
+            {
+                "partner_id": self.env["res.partner"]
+                .create({"name": "Test Partner"})
+                .id,
+                "pricelist_id": self.pricelist.id,
+            }
+        )
+
+        self.order_line = self.env["sale.order.line"].create(
+            {
+                "order_id": self.order.id,
+                "product_id": self.product.id,
+                "name": self.product.name,
+                "product_uom_qty": 1,
+                "fiscal_tax_ids": [(6, 0, [self.tax_icms.id])],
+            }
+        )
+
+    def test_fiscal_price_calculation(self):
+        """Verifies the basic calculation of the fiscal price"""
+        self.order_line._compute_fiscal_price()
+        self.assertEqual(
+            self.order_line.fiscal_price,
+            self.order_line.price_unit,
+            "The fiscal price must be equal to the unit price without adjustments.",
+        )
+
+    def test_fiscal_price_with_taxes(self):
+        """Verifies the calculation with taxes applied"""
+        # Force recalculation with taxes
+        self.order_line._compute_fiscal_price()
+        self.assertEqual(
+            self.order_line.fiscal_price,
+            100.0,  # Base price without tax adjustment
+            "The fiscal price should remain as the base price even with taxes.",
+        )
+
+    def test_price_update_on_product_change(self):
+        """Verifies price update when the product is changed"""
+
+        self.order_line.write(
+            {
+                "product_id": self.new_product.id,
+                "product_uom_qty": 2,
+            }
+        )
+
+        self.assertEqual(
+            self.order_line.price_unit,
+            150.0,  # Price from price list
+            "The price should be updated according to the pricelist when changing the product.",
+        )
+
+        self.assertEqual(
+            self.order_line.fiscal_price,
+            150.0,
+            "The fiscal price should follow the change in unit price.",
+        )
+
+    def test_pricelist_price_application(self):
+        """Verifies correct price application from the pricelist"""
+        new_line = self.env["sale.order.line"].create(
+            {
+                "order_id": self.order.id,
+                "product_id": self.new_product.id,
+                "name": self.new_product.name,
+                "product_uom_qty": 1,
+            }
+        )
+
+        self.assertEqual(
+            new_line.price_unit,
+            150.0,
+            "New products should have their price set according to the pricelist.",
+        )
+
+    def test_tax_recalculation_on_product_change(self):
+        """Verifies if taxes are recalculated when the product is changed"""
+        self.order_line.product_id = self.new_product
+        self.order_line._onchange_product_id_custom_price()
+
+        self.assertTrue(
+            self.order_line.fiscal_tax_ids,
+            "Fiscal taxes should be updated when the product is changed.",
+        )
+
+        self.assertEqual(
+            len(self.order_line.fiscal_tax_ids),
+            1,
+            "It should retain only the configured taxes.",
+        )
+
+    def test_empty_order_line(self):
+        """Testa uma linha vazia sem fiscal_price."""
+        empty_line = self.env["sale.order.line"].create(
+            {
+                "order_id": self.order.id,
+                "name": "Empty Line",
+                "display_type": "line_note",
+            }
+        )
+        self.assertEqual(
+            empty_line.price_unit, 0.0, "Empty line should have zero price"
+        )
+        self.assertFalse(
+            empty_line.fiscal_price, "Empty line should have no fiscal price"
+        )

--- a/falker_sale_price_control/views/sale_order_line_view.xml
+++ b/falker_sale_price_control/views/sale_order_line_view.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_order_form_fiscal_price_control" model="ir.ui.view">
+        <field name="name">sale.order.form.fiscal.price.control</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="l10n_br_sale.l10n_br_sale_order_form" />
+        <field name="arch" type="xml">
+            <data>
+                <!-- Make price_unit read-only -->
+                <xpath
+                    expr="//field[@name='order_line']/form//field[@name='price_unit']"
+                    position="attributes"
+                >
+                    <attribute name="readonly">1</attribute>
+                </xpath>
+
+                <!-- Make fiscal_price read-only -->
+                <xpath
+                    expr="//field[@name='order_line']/form//field[@name='fiscal_price']"
+                    position="attributes"
+                >
+                    <attribute name="readonly">1</attribute>
+                </xpath>
+            </data>
+        </field>
+    </record>
+</odoo>

--- a/setup/falker_sale_price_control/odoo/addons/falker_sale_price_control
+++ b/setup/falker_sale_price_control/odoo/addons/falker_sale_price_control
@@ -1,0 +1,1 @@
+../../../../falker_sale_price_control

--- a/setup/falker_sale_price_control/setup.py
+++ b/setup/falker_sale_price_control/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION

Computes a `fiscal_price` field based on `price_unit`
Makes `price_unit` and `fiscal_price` readonly
Integrates with pricelists and taxes (such as ICMS)
Includes unit tests to validate business logic and field restrictions