### PR TITLE
[14.0][IMP] falker_sale_price_control: Add user group permissions for price editing

### DIFF
--- a/falker_sale_price_control/__manifest__.py
+++ b/falker_sale_price_control/__manifest__.py
@@ -6,7 +6,11 @@
     "license": "AGPL-3",
     "website": "https://github.com/Escodoo/falker-addons",
     "depends": ["l10n_br_sale"],
-    "data": ["views/sale_order_line_view.xml"],
+    "data": [
+        "security/groups.xml",
+        "security/ir.model.access.csv",
+        "views/sale_order_line_view.xml",
+    ],
     "demo": [],
     "test": ["tests/test_sale_order_line.py"],
     "installable": True,

--- a/falker_sale_price_control/models/sale_order_line.py
+++ b/falker_sale_price_control/models/sale_order_line.py
@@ -18,42 +18,43 @@ class SaleOrderLine(models.Model):
             else:
                 line.fiscal_price = line.price_unit
 
-    @api.model
-    def create(self, values):
-        return super().create(values)
-
     def write(self, vals):
-        # Checks if the order has a different pricelist from the one in the context
-        if "pricelist_id" not in vals and any(
-            line.order_id.pricelist_id.id
-            != self.env.context.get("default_pricelist_id")
-            for line in self
-            if line.order_id
-        ):
-            vals["price_unit"] = self._get_price_from_pricelist()
+        if self.env.user.has_group("falker_sale_price_control.group_price_editor"):
+            # Users with permission - price synchronization
+            if "price_unit" in vals:
+                vals["fiscal_price"] = vals["price_unit"]
+            elif "fiscal_price" in vals:
+                vals["price_unit"] = vals["fiscal_price"]
+        else:
+            # Users without permission - apply rules
+            if "pricelist_id" not in vals and any(
+                line.order_id.pricelist_id.id
+                != self.env.context.get("default_pricelist_id")
+                for line in self
+                if line.order_id
+            ):
+                vals["price_unit"] = self._get_price_from_pricelist()
 
-        # Att when change the product
-        if "product_id" in vals:
-            for line in self:
-                order = line.order_id
-                product = self.env["product.product"].browse(vals["product_id"])
-                quantity = vals.get("product_uom_qty", line.product_uom_qty)
+            if "product_id" in vals:
+                for line in self:
+                    order = line.order_id
+                    product = self.env["product.product"].browse(vals["product_id"])
+                    quantity = vals.get("product_uom_qty", line.product_uom_qty)
 
-                if order.pricelist_id:
-                    price = order.pricelist_id.with_context(
-                        uom=product.uom_id.id, date=order.date_order
-                    ).get_product_price(product, quantity, order.partner_id)
+                    if order.pricelist_id:
+                        price = order.pricelist_id.with_context(
+                            uom=product.uom_id.id, date=order.date_order
+                        ).get_product_price(product, quantity, order.partner_id)
 
-                    vals["price_unit"] = price
-                    vals["fiscal_price"] = price
+                        vals["price_unit"] = price
+                        vals["fiscal_price"] = price
 
         return super().write(vals)
 
     def _get_price_from_pricelist(self):
-        """Obtém o preço atualizado da lista de preços com tratamento para linhas vazias"""
+        """Get price from price list"""
         self.ensure_one()
 
-        # If it's a line without product, return 0
         if not self.product_id or self.display_type == "line_note":
             return 0.0
 
@@ -63,9 +64,16 @@ class SaleOrderLine(models.Model):
             self.product_id, self.product_uom_qty, self.order_id.partner_id
         )
 
-    @api.onchange("product_id")
-    def _onchange_product_id_custom_price(self):
-        if not self.product_id:
-            return
-        self.product_id_change()
+    @api.onchange("product_id", "product_uom_qty")
+    def _onchange_product_quantity(self):
+        """Att price when change product or quantity"""
+        if not self.env.user.has_group("falker_sale_price_control.group_price_editor"):
+            if self.product_id:
+                price = self._get_price_from_pricelist()
+                self.price_unit = price
+                self.fiscal_price = price
+
+        # Onchange original from Odoo
+        if hasattr(super(), "product_id_change"):
+            super().product_id_change()
         self._compute_tax_id()

--- a/falker_sale_price_control/security/groups.xml
+++ b/falker_sale_price_control/security/groups.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <!-- Group that allows change price on sale order -->
+    <record id="group_price_editor" model="res.groups">
+        <field name="name">FALKER - Editor de Preços</field>
+        <field name="category_id" ref="base.module_category_sales" />
+    </record>
+</odoo>

--- a/falker_sale_price_control/security/ir.model.access.csv
+++ b/falker_sale_price_control/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_sale_order_line_price_control,sale.order.line.price.control,model_sale_order_line,base.group_user,1,1,1,0

--- a/falker_sale_price_control/tests/test_sale_order_line.py
+++ b/falker_sale_price_control/tests/test_sale_order_line.py
@@ -6,12 +6,30 @@ from odoo.tests.common import TransactionCase
 class TestSaleOrderLinePriceControl(TransactionCase):
     def setUp(self):
         super().setUp()
+        # Basic setup
+        self.tax = self.env["account.tax"].create(
+            {
+                "name": "Tax 10%",
+                "amount": 10.0,
+                "type_tax_use": "sale",
+            }
+        )
+
         self.tax_icms = self.env["account.tax"].create(
             {
                 "name": "ICMS Test",
                 "type_tax_use": "sale",
                 "amount_type": "percent",
                 "amount": 17.0,
+            }
+        )
+
+        self.tax_ipi = self.env["account.tax"].create(
+            {
+                "name": "IPI Test",
+                "type_tax_use": "sale",
+                "amount_type": "percent",
+                "amount": 5.0,
             }
         )
 
@@ -27,6 +45,14 @@ class TestSaleOrderLinePriceControl(TransactionCase):
             {
                 "name": "New Test Product",
                 "list_price": 200.0,
+                "taxes_id": [(6, 0, [self.tax_icms.id, self.tax_ipi.id])],
+            }
+        )
+
+        self.discount_product = self.env["product.product"].create(
+            {
+                "name": "Discount Product",
+                "list_price": 50.0,
                 "taxes_id": [(6, 0, [self.tax_icms.id])],
             }
         )
@@ -35,6 +61,7 @@ class TestSaleOrderLinePriceControl(TransactionCase):
             {
                 "name": "Test Pricelist",
                 "currency_id": self.env.company.currency_id.id,
+                "discount_policy": "without_discount",
             }
         )
 
@@ -44,6 +71,16 @@ class TestSaleOrderLinePriceControl(TransactionCase):
                 "applied_on": "0_product_variant",
                 "product_id": self.new_product.id,
                 "fixed_price": 150.0,
+            }
+        )
+
+        self.discount_pricelist_item = self.env["product.pricelist.item"].create(
+            {
+                "pricelist_id": self.pricelist.id,
+                "applied_on": "0_product_variant",
+                "product_id": self.discount_product.id,
+                "compute_price": "percentage",
+                "percent_price": 20.0,  # 20% discount
             }
         )
 
@@ -77,30 +114,26 @@ class TestSaleOrderLinePriceControl(TransactionCase):
 
     def test_fiscal_price_with_taxes(self):
         """Verifies the calculation with taxes applied"""
-        # Force recalculation with taxes
         self.order_line._compute_fiscal_price()
         self.assertEqual(
             self.order_line.fiscal_price,
-            100.0,  # Base price without tax adjustment
+            100.0,
             "The fiscal price should remain as the base price even with taxes.",
         )
 
     def test_price_update_on_product_change(self):
         """Verifies price update when the product is changed"""
-
         self.order_line.write(
             {
                 "product_id": self.new_product.id,
                 "product_uom_qty": 2,
             }
         )
-
         self.assertEqual(
             self.order_line.price_unit,
-            150.0,  # Price from price list
+            150.0,
             "The price should be updated according to the pricelist when changing the product.",
         )
-
         self.assertEqual(
             self.order_line.fiscal_price,
             150.0,
@@ -117,7 +150,6 @@ class TestSaleOrderLinePriceControl(TransactionCase):
                 "product_uom_qty": 1,
             }
         )
-
         self.assertEqual(
             new_line.price_unit,
             150.0,
@@ -125,23 +157,41 @@ class TestSaleOrderLinePriceControl(TransactionCase):
         )
 
     def test_tax_recalculation_on_product_change(self):
-        """Verifies if taxes are recalculated when the product is changed"""
-        self.order_line.product_id = self.new_product
-        self.order_line._onchange_product_id_custom_price()
-
-        self.assertTrue(
-            self.order_line.fiscal_tax_ids,
-            "Fiscal taxes should be updated when the product is changed.",
+        """Test tax recalculation when changing products"""
+        test_product = self.env["product.product"].create(
+            {
+                "name": "Test Product for Tax Change",
+                "list_price": 75.0,
+                "taxes_id": [(6, 0, [self.tax.id])],
+            }
         )
 
+        self.order_line.write(
+            {
+                "product_id": test_product.id,
+                "product_uom_qty": 1,
+            }
+        )
+        self.order_line.product_id_change()
+
         self.assertEqual(
-            len(self.order_line.fiscal_tax_ids),
-            1,
-            "It should retain only the configured taxes.",
+            self.order_line.price_unit,
+            75.0,
+            "Price should be updated to the product's list price",
+        )
+        self.assertEqual(
+            self.order_line.tax_id,
+            self.tax,
+            "Taxes should be updated to the product's taxes",
+        )
+        self.assertEqual(
+            self.order_line.fiscal_price,
+            75.0,
+            "Fiscal price should follow the unit price",
         )
 
     def test_empty_order_line(self):
-        """Testa uma linha vazia sem fiscal_price."""
+        """Test a line without fiscal_price."""
         empty_line = self.env["sale.order.line"].create(
             {
                 "order_id": self.order.id,
@@ -154,4 +204,65 @@ class TestSaleOrderLinePriceControl(TransactionCase):
         )
         self.assertFalse(
             empty_line.fiscal_price, "Empty line should have no fiscal price"
+        )
+
+    def test_multiple_taxes_impact(self):
+        """Verify fiscal price with multiple taxes"""
+        new_line = self.env["sale.order.line"].create(
+            {
+                "order_id": self.order.id,
+                "product_id": self.new_product.id,
+                "name": self.new_product.name,
+                "product_uom_qty": 1,
+                "fiscal_tax_ids": [(6, 0, [self.tax_icms.id, self.tax_ipi.id])],
+            }
+        )
+
+        self.assertEqual(
+            new_line.fiscal_price,
+            150.0,
+            "Fiscal price should be equal to unit price regardless of multiple taxes",
+        )
+
+    def test_pricelist_discount_application(self):
+        """Test fiscal price with pricelist percentage discount"""
+        discount_line = self.env["sale.order.line"].create(
+            {
+                "order_id": self.order.id,
+                "product_id": self.discount_product.id,
+                "name": self.discount_product.name,
+                "product_uom_qty": 2,
+            }
+        )
+
+        expected_price = 50.0 * 0.8  # 20% discount from pricelist
+        self.assertEqual(
+            discount_line.price_unit,
+            expected_price,
+            "Price should respect the percentage discount from pricelist",
+        )
+        self.assertEqual(
+            discount_line.fiscal_price,
+            expected_price,
+            "Fiscal price should follow the discounted price",
+        )
+
+    def test_zero_quantity_line(self):
+        """Test behavior when quantity is zero"""
+        self.order_line.write({"product_uom_qty": 0})
+        self.order_line._compute_fiscal_price()
+
+        self.assertEqual(
+            self.order_line.fiscal_price,
+            100.0,
+            "Fiscal price should remain unchanged even with zero quantity",
+        )
+
+    def test_fiscal_price_after_order_confirmation(self):
+        """Verify fiscal price persists after order confirmation"""
+        self.order.action_confirm()
+        self.assertEqual(
+            self.order_line.fiscal_price,
+            100.0,
+            "Fiscal price should remain after order confirmation",
         )

--- a/falker_sale_price_control/views/sale_order_line_view.xml
+++ b/falker_sale_price_control/views/sale_order_line_view.xml
@@ -5,23 +5,39 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="l10n_br_sale.l10n_br_sale_order_form" />
         <field name="arch" type="xml">
-            <data>
-                <!-- Make price_unit read-only -->
-                <xpath
-                    expr="//field[@name='order_line']/form//field[@name='price_unit']"
-                    position="attributes"
-                >
-                    <attribute name="readonly">1</attribute>
-                </xpath>
+            <!-- price_unit can be edited only by authorized group -->
+            <xpath
+                expr="//field[@name='order_line']/form//field[@name='price_unit']"
+                position="attributes"
+            >
+                <attribute
+                    name="groups"
+                >falker_sale_price_control.group_price_editor</attribute>
+            </xpath>
 
-                <!-- Make fiscal_price read-only -->
-                <xpath
-                    expr="//field[@name='order_line']/form//field[@name='fiscal_price']"
-                    position="attributes"
-                >
-                    <attribute name="readonly">1</attribute>
-                </xpath>
-            </data>
+            <!-- price_unit is readonly for non-authorized users -->
+            <xpath
+                expr="//field[@name='order_line']/form//field[@name='price_unit']"
+                position="after"
+            >
+                <field
+                    name="price_unit"
+                    readonly="1"
+                    groups="!falker_sale_price_control.group_price_editor"
+                />
+            </xpath>
+
+            <!-- fiscal_price is readonly for non-authorized users -->
+            <xpath
+                expr="//field[@name='order_line']/form//field[@name='fiscal_price']"
+                position="after"
+            >
+                <field
+                    name="fiscal_price"
+                    readonly="1"
+                    groups="!falker_sale_price_control.group_price_editor"
+                />
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
- Created 'group_price_editor' security group
- Allows price adjustments (both increases and decreases) for authorized users
- Regular users see prices as readonly